### PR TITLE
[#2237405] Update Rakefile 

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -15,5 +15,7 @@ end
 
 task :sync do
   puts 'Syncing files to kudos web'
-  system('rsync -av ./build/ ../kudos/public/api-docs/')
+  system('rsync -av ./build/index.html ../kudos/app/views/api_docs/client_api/')
+  FileUtils.rm('./build/index.html')
+  system('rsync -av ./build/ ../kudos/public/api_docs/')
 end


### PR DESCRIPTION
Update Rakefile to sync generated doc files to two different locations

index file to: app/views/api_docs/client_api/index.html
everything else to: public/api_docs

This facilitates locking down API doc access to auth'd users only.
